### PR TITLE
Fixed required extension in README and enhanced it structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
     Python Docs<br>
     Dark Theme
 </h1>
-<details align="center">
-    <summary>Preview Image</summary>
+<details align="center"><summary>Preview Image</summary>
     <img src="./images/preview.png">
 </details>
 
@@ -11,7 +10,7 @@
 This repository contains the userstyle dark theme for python documentation and other web pages that inherit the stylesheet from official docs.
 
 ## Installation
-1. Ensure that **Stylish** extension ([Chrome](https://chrome.google.com/webstore/detail/stylish-custom-themes-for/fjnbnpbmkenffdnngjfgmeleoegfcffe), [Firefox](https://addons.mozilla.org/ru/firefox/addon/stylish/)) is installed in your browser
+1. Ensure that **Stylus** extension ([Chrome](https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne), [Firefox](https://addons.mozilla.org/ru/firefox/addon/styl-us/)) is installed in your browser
 2. 📦 [Install the usercss](https://github.com/maximilionus/python_docs_dark/raw/master/python_docs_dark.user.css)
 
 ## Supported Domains
@@ -20,4 +19,4 @@ Here's list of domains that are currenlty supported by this userstyle.
 - docs.python.org
 - packaging.python.org
 
-> If you know of other domains that inherited the style from docs.python.org, you can notify me via [Issues](https://github.com/maximilionus/python_docs_dark/issues)
+> If you know of other domains that inherited the style from docs.python.org, you can notify me by [creating the new issue](https://github.com/maximilionus/python_docs_dark/issues/new?labels=add%20to%20supported%20pages)


### PR DESCRIPTION
There was a problem with wrong required extension installation name and link in README file. This pull request fixes the #1 issue and enhances the structure of README - Creating the issue from the link in `#Supported Domains` now lead to new issue creation page and will automatically attach the `add to supported pages` label.

Should be merged to `master` ASAP!